### PR TITLE
Fix NPM title and minor README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,10 @@ at the root of the repository.
 [travis-image]:      https://travis-ci.org/angelsanz/regularity.svg?branch=master
 [travis-url]:        https://travis-ci.org/angelsanz/regularity
 [coveralls-image]:   https://coveralls.io/repos/angelsanz/regularity/badge.svg?branch=master
-[coverals-url]:      https://coveralls.io/r/angelsanz/regularity?branch=master
+[coveralls-url]:      https://coveralls.io/r/angelsanz/regularity?branch=master
 [codeclimate-image]: https://codeclimate.com/github/angelsanz/regularity/badges/gpa.svg
 [codeclimate-url]:   https://codeclimate.com/github/angelsanz/regularity
 [nodeico-image]:     https://nodei.co/npm/regularity.png?downloads=true&stars=true
 [nodeico-url]:       https://nodei.co/npm/regularity/
 
-[regexp-mdn]:        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+[regexp-mdn]:        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ at the root of the repository.
 [travis-image]:      https://travis-ci.org/angelsanz/regularity.svg?branch=master
 [travis-url]:        https://travis-ci.org/angelsanz/regularity
 [coveralls-image]:   https://coveralls.io/repos/angelsanz/regularity/badge.svg?branch=master
-[coveralls-url]:      https://coveralls.io/r/angelsanz/regularity?branch=master
+[coveralls-url]:     https://coveralls.io/r/angelsanz/regularity?branch=master
 [codeclimate-image]: https://codeclimate.com/github/angelsanz/regularity/badges/gpa.svg
 [codeclimate-url]:   https://codeclimate.com/github/angelsanz/regularity
 [nodeico-image]:     https://nodei.co/npm/regularity.png?downloads=true&stars=true

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # regularity — regular expressions for humans
 
-[![Build Status](https://travis-ci.org/angelsanz/regularity.svg?branch=master)](https://travis-ci.org/angelsanz/regularity)
-[![Coverage Status](https://coveralls.io/repos/angelsanz/regularity/badge.svg?branch=master)](https://coveralls.io/r/angelsanz/regularity?branch=master)
-[![Code Climate](https://codeclimate.com/github/angelsanz/regularity/badges/gpa.svg)](https://codeclimate.com/github/angelsanz/regularity)
+[![Build Status][travis-image]][travis-url]
+[![Coverage Status][coveralls-image]][coveralls-url]
+[![Code Climate][codeclimate-image]][codeclimate-url]
 
-[![NPM](https://nodei.co/npm/regularity.png?downloads=true&stars=true)](https://nodei.co/npm/regularity/)
+[![NPM][nodeico-image]][nodeico-url]
 
 
 
@@ -80,7 +80,7 @@ with the proper arguments.
 
 When you are done building the regular expression,
 tell **regularity** so by calling [`done`](#done).
-This call will return a native [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+This call will return a native [`RegExp`][regexp-mdn]
 implementing the pattern which you described
 using the methods of the **regularity** object,
 which you can then use
@@ -242,7 +242,7 @@ also expose the following methods:
   may span multiple lines.
 
 - <a name="done">[**`done()`**](#done)</a>:
-  Return the native [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) object
+  Return the native [`RegExp`][regexp-mdn] object
   representing the pattern which you described
   by means of the previous calls
   on that **regularity** instance.
@@ -258,7 +258,7 @@ Original idea and [Ruby](https://rubygems.org/gems/regularity)
 [implementation](https://github.com/andrewberls/regularity)
 are by [Andrew Berls](https://github.com/andrewberls/).
 
-If you are unsure about the [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+If you are unsure about the [`RegExp`][regexp-mdn]
 you just built, [`regulex`](https://jex.im/regulex)
 is a great tool which will draw you
 a fancy _railroad diagram_ of it.
@@ -270,3 +270,16 @@ This project is licensed under the
 [MIT License](http://opensource.org/licenses/MIT).
 For more details, see the [`LICENSE`](./LICENSE) file
 at the root of the repository.
+
+
+
+[travis-image]:      https://travis-ci.org/angelsanz/regularity.svg?branch=master
+[travis-url]:        https://travis-ci.org/angelsanz/regularity
+[coveralls-image]:   https://coveralls.io/repos/angelsanz/regularity/badge.svg?branch=master
+[coverals-url]:      https://coveralls.io/r/angelsanz/regularity?branch=master
+[codeclimate-image]: https://codeclimate.com/github/angelsanz/regularity/badges/gpa.svg
+[codeclimate-url]:   https://codeclimate.com/github/angelsanz/regularity
+[nodeico-image]:     https://nodei.co/npm/regularity.png?downloads=true&stars=true
+[nodeico-url]:       https://nodei.co/npm/regularity/
+
+[regexp-mdn]:        https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ of all the supported use cases.
 
 Bear in mind that, in what follows,
 `pattern` stands for any string,
-which migt or might not be
+which might or might not be
 any of the _special identifiers_,
 and which might include characters
 which need escaping (you don't need

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ also expose the following methods:
   (instead of matching just the first,
   which is the default behaviour).
 
-- <a name="multiline">[**`mulltiLine()`**](#multiline)</a>:
+- <a name="multiline">[**`multiline()`**](#multiline)</a>:
   Specify that the input
   may span multiple lines.
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ also expose the following methods:
   which is the default behaviour).
 
 - <a name="multiline">[**`multiline()`**](#multiline)</a>:
-  Specify that the input
+  Specify that the string
+  against which the [`RegExp`][regexp-mdn] is to be matched
   may span multiple lines.
 
 - <a name="done">[**`done()`**](#done)</a>:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # regularity — regular expressions for humans
+
 [![Build Status](https://travis-ci.org/angelsanz/regularity.svg?branch=master)](https://travis-ci.org/angelsanz/regularity)
 [![Coverage Status](https://coveralls.io/repos/angelsanz/regularity/badge.svg?branch=master)](https://coveralls.io/r/angelsanz/regularity?branch=master)
 [![Code Climate](https://codeclimate.com/github/angelsanz/regularity/badges/gpa.svg)](https://codeclimate.com/github/angelsanz/regularity)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "regularity",
   "version": "0.5.0",
+  "description": "regular expressions for humans",
   "main": "lib/regularity.js",
   "author": "Fernando Martinez de la Cueva <me@oinak.com> (http://oinak.com/)",
   "contributors": [

--- a/spec/regularity_spec.js
+++ b/spec/regularity_spec.js
@@ -370,7 +370,7 @@ describe("Regularity", function() {
             regularity.insensitive();
         });
 
-        it("sets the appropriate native flag", function() {
+        it("sets the 'insensitive' native flag", function() {
             var regexp = regularity.done();
             expect(regexp.ignoreCase).toBe(true);
         });
@@ -387,7 +387,7 @@ describe("Regularity", function() {
             regularity.global();
         });
 
-        it("sets the appropriate native flag", function() {
+        it("sets the 'global' native flag", function() {
             var regexp = regularity.done();
             expect(regexp.global).toBe(true);
         });
@@ -404,7 +404,7 @@ describe("Regularity", function() {
             regularity.multiline();
         });
 
-        it("sets the appropriate native flag", function() {
+        it("sets the 'multiline' native flag", function() {
             var regexp = regularity.done();
             expect(regexp.multiline).toBe(true);
         });


### PR DESCRIPTION
The title in the README was being rendered badly by npmjs.com, I hope this fixes it.
